### PR TITLE
added support for a vault cert that doesn't need to be installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
   copy:
     src: "{{ consul_template_vault_ssl.ca_cert.split('/')[-1] }}"
     dest: "{{ consul_template_work_dir }}/{{ consul_template_vault_ssl.ca_cert.split('/')[-1] }}"
-  when: consul_template_vault_ssl.ca_cert
+  when: consul_template_vault_ssl.ca_cert is defined
 
 - name: Copy template sources
   copy:

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -93,11 +93,15 @@ vault {
 {% if consul_template_vault_ssl.key|default(false) %}
     key = "{{ consul_template_vault_ssl.key }}"
 {% endif %}
-{% if consul_template_vault_ssl.ca_cert|length %}
+{% if consul_template_vault_ssl.ca_cert|default(false) %}
     ca_cert = "{{ consul_template_work_dir ~ '/' ~ (consul_template_vault_ssl.ca_cert.split('/')[-1]) }}"
 {% endif %}
+{% if consul_template_vault_ssl.ca_path|default(false) %}
     ca_path = "{{ consul_template_vault_ssl.ca_path|default('') }}"
+{% endif %}
+{% if consul_template_vault_ssl.server_name|default(false) %}
     server_name = "{{ consul_template_vault_ssl.server_name|default('my-server.com') }}"
+{% endif %}
   }
 {% endif -%}
 


### PR DESCRIPTION
The current role would fail if a vault certificate (consul_template_vault_ssl.ca_path) was not provided