### PR TITLE
added ability to provide jinja2 templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,16 +56,17 @@ consul_template_templates: []          # See example below
 #########################
 ##  Configuration Example
 ##
-## consul_template_template:
-##   source: "/path/on/disk/to/template.ctmpl"  # mutually exclusive with "contents"
-##   destination: "/path/on/disk/where/template/will/render.txt"
-##   command: "restart service foo"
-##   command_timeout: "60s"
-##   perms: "0600"
-##   backup: true
-##   left_delimiter:  "{{"
-##   right_delimiter: "}}"
-##   wait: { min: "2s", max: "10s" }
+## consul_template_templates:
+##   - source: "/path/on/disk/to/template.tpl"  # mutually exclusive with "contents"
+##     destination: "/path/on/disk/where/template/will/render.txt"
+##     command: "restart service foo"
+##     command_timeout: "60s"
+##     perms: "0600"
+##     copy_method:  # copy or template
+##     backup: true
+##     left_delimiter:  "{{"
+##     right_delimiter: "}}"
+##     wait: { min: "2s", max: "10s" }
 ## 
 ## consul_template_consul_auth:
 ##   enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,8 +33,15 @@
     src: "{{ item.source }}"
     dest: "{{ consul_template_work_dir }}/{{ item.source.split('/')[-1] }}"
   when: consul_template_templates
-  with_items: "{{ consul_template_templates }}"
+  with_items: "{{ consul_template_templates | selectattr ('copy_method', 'undefined') | list }} + {{ consul_template_templates | selectattr ('copy_method', 'defined') | selectattr('copy_method', 'match', '(?i)^copy') | list }}"
   
+- name: Use ansible template module for template sources
+  template:
+    src: "{{ item.source }}"
+    dest: "{{ consul_template_work_dir }}/{{ (item.source.split('/')[-1] | splitext)[0] }}.tpl"
+  when: consul_template_templates
+  with_items: "{{ consul_template_templates | selectattr ('copy_method', 'defined') | selectattr('copy_method', 'match', '(?i)^template') | list }}"
+
 - name: Ensure consul-template bin directory exists
   file: dest={{ consul_template_bin_dir }} mode=0755 state=directory
 

--- a/tasks/template-config.yml
+++ b/tasks/template-config.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Ensure that consul-template template file to render is present
-  stat: path="{{ consul_template_work_dir }}/{{ item.source.split('/')[-1] }}" 
+  stat: path="{{ consul_template_work_dir }}/{% if (item.source.split('/')[-1] | splitext)[1] | lower == '.j2' %}{{ (item.source.split('/')[-1] | splitext)[0] }}.tpl{% else %}{{ item.source.split('/')[-1] }}{% endif %}"
   register: t
 
-- set_fact: tplcfg={{ item.source.split('/')[-1] | replace('.tpl', '') }}
+- set_fact: tplcfg={{ (item.source.split('/')[-1] | splitext)[0] }}
 - debug: var=tplcfg
 
 - name: Fail if consul-template template file does not exist OR contents was not provided


### PR DESCRIPTION
Previously consul-template templates could only be copied.  This change allows consul-templates to be provided in a jinja2 format and ansible will template the file when installing instead of just copying the template