### PR TITLE
switched to ansible filter basename for certificate copy

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Copy vault ssl certificate
   copy:
     src: "{{ consul_template_vault_ssl.ca_cert.split('/')[-1] }}"
-    dest: "{{ consul_template_work_dir }}/{{ consul_template_vault_ssl.ca_cert.split('/')[-1] }}"
+    dest: "{{ consul_template_work_dir }}/{{ consul_template_vault_ssl.ca_cert | basename }}"
   when: consul_template_vault_ssl.ca_cert is defined
 
 - name: Copy template sources

--- a/templates/defaults.conf.j2
+++ b/templates/defaults.conf.j2
@@ -94,7 +94,7 @@ vault {
     key = "{{ consul_template_vault_ssl.key }}"
 {% endif %}
 {% if consul_template_vault_ssl.ca_cert|default(false) %}
-    ca_cert = "{{ consul_template_work_dir ~ '/' ~ (consul_template_vault_ssl.ca_cert.split('/')[-1]) }}"
+    ca_cert = "{{ consul_template_work_dir ~ '/' ~ (consul_template_vault_ssl.ca_cert | basename) }}"
 {% endif %}
 {% if consul_template_vault_ssl.ca_path|default(false) %}
     ca_path = "{{ consul_template_vault_ssl.ca_path|default('') }}"


### PR DESCRIPTION
Split isn't a true ansible filter it is actually using the python split method.  So switched to a true ansible filter, basename